### PR TITLE
Making sure a fresh site's migration actually succeeds

### DIFF
--- a/lizard_map/migrations/0005_auto__del_workspacecollagesnippetgroup__del_workspaceitem__del_workspa.py
+++ b/lizard_map/migrations/0005_auto__del_workspacecollagesnippetgroup__del_workspaceitem__del_workspa.py
@@ -7,7 +7,7 @@ from django.db import models
 class Migration(SchemaMigration):
 
     def forwards(self, orm):
-        
+
         # Deleting model 'WorkspaceCollageSnippetGroup'
         db.delete_table('lizard_map_workspacecollagesnippetgroup')
 
@@ -67,7 +67,7 @@ class Migration(SchemaMigration):
             ('restrict_to_month', self.gf('django.db.models.fields.IntegerField')(null=True, blank=True)),
             ('aggregation_period', self.gf('django.db.models.fields.IntegerField')(default=1)),
             ('collage', self.gf('django.db.models.fields.related.ForeignKey')(related_name='collage_items', to=orm['lizard_map.CollageEdit'])),
-            ('identifier', self.gf('lizard_map.fields.JSONField')(default='')),
+            ('identifier', self.gf('lizard_map.fields.JSONField')(default='{}')),
         ))
         db.send_create_signal('lizard_map', ['CollageEditItem'])
 
@@ -120,7 +120,7 @@ class Migration(SchemaMigration):
 
 
     def backwards(self, orm):
-        
+
         # Adding model 'WorkspaceCollageSnippetGroup'
         db.create_table('lizard_map_workspacecollagesnippetgroup', (
             ('layout_y_label', self.gf('django.db.models.fields.CharField')(max_length=80, null=True, blank=True)),
@@ -263,7 +263,7 @@ class Migration(SchemaMigration):
             'clickable': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
             'collage': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'collage_items'", 'to': "orm['lizard_map.CollageEdit']"}),
             'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
-            'identifier': ('lizard_map.fields.JSONField', [], {'default': "''"}),
+            'identifier': ('lizard_map.fields.JSONField', [], {'default': '{}'}),
             'index': ('django.db.models.fields.IntegerField', [], {'default': '100', 'blank': 'True'}),
             'name': ('django.db.models.fields.CharField', [], {'max_length': '80', 'blank': 'True'}),
             'percentile_value': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),

--- a/lizard_map/migrations/0006_auto__add_field_backgroundmap_is_base_layer.py
+++ b/lizard_map/migrations/0006_auto__add_field_backgroundmap_is_base_layer.py
@@ -7,13 +7,13 @@ from django.db import models
 class Migration(SchemaMigration):
 
     def forwards(self, orm):
-        
+
         # Adding field 'BackgroundMap.is_base_layer'
         db.add_column('lizard_map_backgroundmap', 'is_base_layer', self.gf('django.db.models.fields.BooleanField')(default=True), keep_default=False)
 
 
     def backwards(self, orm):
-        
+
         # Deleting field 'BackgroundMap.is_base_layer'
         db.delete_column('lizard_map_backgroundmap', 'is_base_layer')
 
@@ -83,7 +83,7 @@ class Migration(SchemaMigration):
             'clickable': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
             'collage': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'collage_items'", 'to': "orm['lizard_map.CollageEdit']"}),
             'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
-            'identifier': ('lizard_map.fields.JSONField', [], {'default': "''"}),
+            'identifier': ('lizard_map.fields.JSONField', [], {'default': '{}'}),
             'index': ('django.db.models.fields.IntegerField', [], {'default': '100', 'blank': 'True'}),
             'name': ('django.db.models.fields.CharField', [], {'max_length': '80', 'blank': 'True'}),
             'percentile_value': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),

--- a/lizard_map/migrations/0007_auto__add_field_workspacestorage_secret_slug.py
+++ b/lizard_map/migrations/0007_auto__add_field_workspacestorage_secret_slug.py
@@ -7,13 +7,13 @@ from django.db import models
 class Migration(SchemaMigration):
 
     def forwards(self, orm):
-        
+
         # Adding field 'WorkspaceStorage.secret_slug'
         db.add_column('lizard_map_workspacestorage', 'secret_slug', self.gf('django.db.models.fields.CharField')(max_length=16, null=True), keep_default=False)
 
 
     def backwards(self, orm):
-        
+
         # Deleting field 'WorkspaceStorage.secret_slug'
         db.delete_column('lizard_map_workspacestorage', 'secret_slug')
 
@@ -83,7 +83,7 @@ class Migration(SchemaMigration):
             'clickable': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
             'collage': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'collage_items'", 'to': "orm['lizard_map.CollageEdit']"}),
             'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
-            'identifier': ('lizard_map.fields.JSONField', [], {'default': "''"}),
+            'identifier': ('lizard_map.fields.JSONField', [], {'default': '{}'}),
             'index': ('django.db.models.fields.IntegerField', [], {'default': '100', 'blank': 'True'}),
             'name': ('django.db.models.fields.CharField', [], {'max_length': '80', 'blank': 'True'}),
             'percentile_value': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),

--- a/lizard_map/migrations/0008_auto__chg_field_workspacestorage_owner.py
+++ b/lizard_map/migrations/0008_auto__chg_field_workspacestorage_owner.py
@@ -7,13 +7,13 @@ from django.db import models
 class Migration(SchemaMigration):
 
     def forwards(self, orm):
-        
+
         # Changing field 'WorkspaceStorage.owner'
         db.alter_column('lizard_map_workspacestorage', 'owner_id', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['auth.User'], null=True))
 
 
     def backwards(self, orm):
-        
+
         # Changing field 'WorkspaceStorage.owner'
         db.alter_column('lizard_map_workspacestorage', 'owner_id', self.gf('django.db.models.fields.related.ForeignKey')(default=1, to=orm['auth.User']))
 
@@ -83,7 +83,7 @@ class Migration(SchemaMigration):
             'clickable': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
             'collage': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'collage_items'", 'to': "orm['lizard_map.CollageEdit']"}),
             'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
-            'identifier': ('lizard_map.fields.JSONField', [], {'default': "''"}),
+            'identifier': ('lizard_map.fields.JSONField', [], {'default': '{}'}),
             'index': ('django.db.models.fields.IntegerField', [], {'default': '100', 'blank': 'True'}),
             'name': ('django.db.models.fields.CharField', [], {'max_length': '80', 'blank': 'True'}),
             'percentile_value': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),


### PR DESCRIPTION
The new jsonfield (at least the one in lizard5 now?) fails on the old defaults in old migrations.
