### PR TITLE
When mk_js_timestamp was changed for the new API so that it returned ISO...

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -39,6 +39,8 @@ Changelog of lizard-map
   the labels and so are now next to the graphs as there's no separate sidebar
   anymore.
 
+- Fix timezones once more.
+
 
 4.28 (2013-05-06)
 -----------------

--- a/lizard_map/testsettings.py
+++ b/lizard_map/testsettings.py
@@ -69,6 +69,8 @@ ADMIN_MEDIA_PREFIX = STATIC_URL + 'admin/'
 LOGGING = setup_logging(BUILDOUT_DIR)
 USE_TZ = True
 
+TIME_ZONE = "Europe/Amsterdam"
+
 #SOUTH_TESTS_MIGRATE = False
 
 LIZARD_MAP_STANDALONE = True


### PR DESCRIPTION
... dates

instead of epoch timestamps, the timezone handling and the tests were broken.
This fixes that.
