### PR TITLE
Reload faulty graphs automatically

### DIFF
--- a/lizard_map/static/lizard_map/lizard_map.js
+++ b/lizard_map/static/lizard_map/lizard_map.js
@@ -1844,8 +1844,18 @@ function reloadDynamicGraph($graph, callback, force) {
             on_loaded();
             $graph.data('fault_when_loading', true);
             if (!flot_x_global_min) {
-                // Not flot dynamic reloading; so it is ok to show graph-disabling error.
-                $graph.html('Waarschijnlijk duurt het inlezen van de data lang. Probeer over 20 seconden de <a href="javascript:reloadFaultyGraphs()">grafieken opnieuw te laden</a>.');
+                // Not flot dynamic reloading; so it is ok to show
+                // a graph-disabling html error.
+                // The message is shown for 15 seconds, afterwards the graphs
+                // are reloaded automatically.
+                if (reload_faulty_timeout) {
+                    clearTimeout(reload_faulty_timeout);
+                }
+                reload_faulty_timeout = setTimeout(reloadFaultyGraphs, 15000);
+                $graph.html(
+                    '<i class="icon-exclamation-sign text-success"></i> ' +
+                    'U heeft een grote hoeveelheid data opgevraagd. Het ' +
+                    'opbouwen van de grafiek gaat enkele seconden duren.');
             }
         };
 


### PR DESCRIPTION
Als een grafiek te lang duurt met laden krijg je een vriendelijker melding. Na 15 seconden wordt automatisch een nieuwe poging gedaan:

![reload-in-lizard5](https://cloud.githubusercontent.com/assets/121433/3428205/abc59aee-003d-11e4-9d40-57a766f98f4c.gif)
